### PR TITLE
hotfix: prevent NPE crash on rotation

### DIFF
--- a/app/src/main/java/com/heimcontrol/mobile/RCSwitches.java
+++ b/app/src/main/java/com/heimcontrol/mobile/RCSwitches.java
@@ -52,8 +52,11 @@ public class RCSwitches extends Fragment implements RefreshInterface {
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
         this.url = prefs.getString("heimcontrol_url", "");
 
-        if (getKey().equals("") || this.url.equals(""))
-        {
+        String key = getKey();
+
+        // this is not doing what it should FIXME
+        // workaround for now to prevent crashes
+        if ((key != null && key.equals("")) || this.url.equals("")) {
             CharSequence text = "No key available, please check heimcontrol url in settings and log in.";
             int duration = Toast.LENGTH_SHORT;
             Toast toast = makeText(context, text, duration);

--- a/app/src/main/java/com/heimcontrol/mobile/Switches.java
+++ b/app/src/main/java/com/heimcontrol/mobile/Switches.java
@@ -57,7 +57,11 @@ public class Switches extends Fragment implements RefreshInterface {
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
         this.url = prefs.getString("heimcontrol_url", "");
 
-        if (getKey().equals("") || this.url.equals(""))
+        String key = getKey();
+
+        // this is not doing what it should FIXME
+        // workaround for now to prevent crashes
+        if ((key != null && key.equals("")) || this.url.equals(""))
         {
             CharSequence text = "No key available, please check heimcontrol url in settings and log in.";
             int duration = Toast.LENGTH_SHORT;


### PR DESCRIPTION
Checks whether `key` is `null` and if yes bypasses login check.
This will likely have unintended consequences, but at least the
app doesn't crash on rotation, and seems to work fine.
