### PR TITLE
Switches as GridLayout (slight spacing fixes)

### DIFF
--- a/app/src/main/res/layout/fragment_switches.xml
+++ b/app/src/main/res/layout/fragment_switches.xml
@@ -1,54 +1,62 @@
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<GridLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:id="@+id/switchesListItem"
-
     android:paddingLeft="@dimen/activity_horizontal_margin"
     android:paddingRight="@dimen/activity_horizontal_margin"
     android:paddingTop="@dimen/activity_vertical_margin"
-    android:paddingBottom="@dimen/activity_vertical_margin">
-
+    android:paddingBottom="@dimen/activity_vertical_margin"
+    android:rowCount="2"
+    android:columnCount="3" >
 
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:id="@+id/pinLabel"
-        android:text="Pin"/>
+        android:text="Pin"
+        android:layout_row="0"
+        android:layout_column="0" />
+
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:id="@+id/pin"
         android:textStyle="bold"
-        android:layout_alignTop="@+id/pinLabel"
-        android:layout_toRightOf="@+id/pinLabel"
-        android:width="20dp"
-        android:layout_marginLeft="80dp" />
+        android:layout_row="0"
+        android:layout_column="1"
+        android:paddingLeft="8dp"
+        android:paddingRight="8dp"
+        android:text="-" />
+
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="20dp"
         android:id="@+id/descriptionLabel"
-        android:text="Description"/>
+        android:text="Description"
+        android:layout_row="1"
+        android:layout_column="0" />
 
     <TextView
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:id="@+id/description"
-    android:textStyle="bold"
-    android:layout_alignTop="@+id/descriptionLabel"
-    android:layout_toRightOf="@+id/descriptionLabel"
-    android:layout_marginLeft="36dp" />
-s
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:id="@+id/description"
+        android:textStyle="bold"
+        android:layout_row="1"
+        android:layout_column="1"
+        android:paddingLeft="8dp"
+        android:paddingRight="8dp"
+        android:text="-" />
+
     <Switch
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:id="@+id/pinSwitch"
-        android:layout_alignBottom="@+id/description"
-        android:layout_alignParentRight="true"
-        android:layout_alignParentEnd="true"
-        android:checked="false" />
+        android:checked="false"
+        android:layout_gravity="right|center_vertical"
+        android:layout_row="0"
+        android:layout_rowSpan="2"
+        android:layout_column="2" />
 
-
-</RelativeLayout>
+</GridLayout>
 


### PR DESCRIPTION
Changed `[RC]Switches` `RelativeLayout` to 3 by 2 `GridLayout`.
On my devices, this version lines up nicely, and provides a bit more
space on smaller screens.
